### PR TITLE
Agregar pruebas unitarias para Catalogo (Closes #5)

### DIFF
--- a/src/test/java/com/biblioteca/CatalogoTest.java
+++ b/src/test/java/com/biblioteca/CatalogoTest.java
@@ -1,0 +1,45 @@
+package com.biblioteca;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CatalogoTest {
+
+    private Catalogo catalogo;
+    private Libro libro1;
+    private Libro libro2;
+
+    @BeforeEach
+    void setUp() {
+        catalogo = new Catalogo();
+        libro1 = new Libro("978-0-15-100217-7", "Rebelión en la granja", "George Orwell");
+        libro2 = new Libro("978-0-452-28423-4", "1984", "George Orwell");
+
+        catalogo.agregarLibro(libro1);
+        catalogo.agregarLibro(libro2);
+    }
+
+    @Test
+    void testBuscarPorIsbnExitoso() {
+        Libro libroEncontrado = catalogo.buscarPorIsbn("978-0-15-100217-7");
+        assertNotNull(libroEncontrado);
+        assertEquals("Rebelión en la granja", libroEncontrado.getTitulo());
+    }
+
+    @Test
+    void testBuscarPorIsbnFallido() {
+        Libro libroEncontrado = catalogo.buscarPorIsbn("999-9-99-999999-9");
+        assertNull(libroEncontrado);
+    }
+
+    @Test
+    void testObtenerLibrosDisponibles() {
+        libro1.setEstado(Estado.PRESTADO); // Simulamos que uno está prestado
+
+        var disponibles = catalogo.obtenerLibrosDisponibles();
+        assertEquals(1, disponibles.size());
+        assertEquals("1984", disponibles.get(0).getTitulo());
+    }
+}


### PR DESCRIPTION
## Descripción del Pull Request

- Se implementan las pruebas unitarias para la clase `Catalogo`, incluyendo:
  - Búsqueda de libros por ISBN exitoso.
  - Búsqueda de libros por ISBN fallido (no encontrado).
  - Obtención de libros disponibles.
- Se utilizaron `JUnit5` y `Assert` para validar los comportamientos esperados.
- Se ejecutaron las pruebas utilizando Maven (`mvn clean test`) verificando el correcto funcionamiento.
- Parte de la asistencia para estructurar el código de las pruebas fue realizada utilizando herramientas de IA (ChatGPT), revisando, comprendiendo y validando personalmente cada implementación.

## Evidencia de pruebas exitosas

- Resultado de ejecución: `BUILD SUCCESS` en `mvn clean test`.
- Todas las pruebas unitarias de `CatalogoTest` pasaron correctamente sin fallos.


